### PR TITLE
Fix conform format() not falling back to LSP

### DIFF
--- a/lua/configs/conform.lua
+++ b/lua/configs/conform.lua
@@ -1,6 +1,4 @@
 local options = {
-  lsp_fallback = true,
-
   formatters_by_ft = {
     lua = { "stylua" },
   },

--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -7,7 +7,9 @@ local map = vim.keymap.set
 map("n", ";", ":", { desc = "CMD enter command mode" })
 
 map("n", "<leader>fm", function()
-  require("conform").format()
+  require("conform").format({
+      lsp_fallback = true,
+  })
 end, { desc = "File Format with conform" })
 
 map("i", "jk", "<ESC>", { desc = "Escape insert mode" })


### PR DESCRIPTION
according to conform.nvim documentation, lsp_fallback is a option on the format commands and not a global plugin configuration.
issue was reproduced and fixed with clangd/cpp files