### PR TITLE
Fix incorrect colours for lsp virtual text

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -31,6 +31,7 @@ require("lazy").setup({
 -- load theme
 dofile(vim.g.base46_cache .. "defaults")
 dofile(vim.g.base46_cache .. "statusline")
+dofile(vim.g.base46_cache .. "lsp")
 
 require "nvchad.autocmds"
 


### PR DESCRIPTION
The highlight groups for the lsp virtual text seem to not be initialised properly when starting Neovim with a non-default colour scheme. 

Highlight groups DiagnosticOk, DiagnosticHint, DiagnosticInfo, DiagnosticWarn, and DiagnosticError (and others linked) remain at default value, even though a colour scheme (in my case Catppuccin) has been set in chadrc.lua. Setting the theme in a running Neovim instance via the theme switcher will set the above highlight groups correctly.
This can be reproduced.

I am not sure if this is due to an issue in the main repository, but running the base46 cache for lsp fixed this issue for me.