### PR TITLE
Removed Bug: Multiple offset encoding error by clangd is fixed.

### DIFF
--- a/lua/configs/lspconfig.lua
+++ b/lua/configs/lspconfig.lua
@@ -21,3 +21,15 @@ lspconfig.tsserver.setup {
   on_init = on_init,
   capabilities = capabilities,
 }
+
+-- clangd
+lspconfig.clangd.setup {
+  on_attach = on_attach,
+  capabilities = capabilities,
+
+  cmd = {
+    "clangd",
+    "--offset-encoding=utf-16",
+    "-header-insertion=never"
+  }
+}


### PR DESCRIPTION
Previously the Clangd LSP won't start with C/C++ files or gave `multiple different client offset_encodings detected` error. And the fix for that was in this [reddit](https://www.reddit.com/r/neovim/comments/12qbcua/multiple_different_client_offset_encodings/) post. So, I thought it's better to have it fixed by default.

Thanks.