### PR TITLE
fix path for base64 plugin

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,4 +1,4 @@
-vim.g.base46_cache = vim.fn.stdpath "data" .. "/nvchad/base46/"
+vim.g.base46_cache = vim.fn.stdpath "data" .. "/base46/"
 vim.g.mapleader = " "
 
 -- bootstrap lazy and all plugins


### PR DESCRIPTION
fixes base64 plugins path
![Screenshot 2024-10-02 054403](https://github.com/user-attachments/assets/5e0661c6-b53e-4e0a-8167-41dc0057df0a)
