### PR TITLE
docs: updated chadrc.lua reference to nvconfig.lua to point to v3.0

### DIFF
--- a/lua/chadrc.lua
+++ b/lua/chadrc.lua
@@ -1,5 +1,5 @@
 -- This file needs to have same structure as nvconfig.lua 
--- https://github.com/NvChad/ui/blob/v2.5/lua/nvconfig.lua
+-- https://github.com/NvChad/ui/blob/v3.0/lua/nvconfig.lua
 -- Please read that file to know all available options :( 
 
 ---@type ChadrcConfig


### PR DESCRIPTION
As it stands, the comment in `chadrc.lua` file is pointing to the v2.5 nvconfig, instead of the most recent (and default) v3.0

Discovered this when I had the same problem as the one in the issue: https://github.com/NvChad/NvChad/issues/3009