### PR TITLE
fix: default keymaps of NvChad prevent assignment to `keys`

### DIFF
--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -1,5 +1,3 @@
-require "nvchad.mappings"
-
 -- add yours here
 
 local map = vim.keymap.set

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -1,3 +1,5 @@
+require "nvchad.mappings"
+
 return {
   {
     "stevearc/conform.nvim",


### PR DESCRIPTION
Since `/lua/plugins/` is loaded before `/lua/mappings.lua`, any keys assigned in `keys` will be overwritten by default keymaps of NvChad.
The intended use case is as follows:
```lua
-- /lua/plugins/init.lua
require "nvchad.mappings"
vim.keymap.del('n', '<C-h>')

return {
  {
    "some/plugin",
    keys = {
      { "<C-h>", "<cmd>SomeFunc<CR>" },
    ...
```

or it could be something like:
```lua
-- /lua/plugins/foo.lua
return {
  {
    "some/plugin",
    keys = require "keymaps.some-plugin",
    ...
```

```lua
-- /lua/keymaps/some-plugin.lua
vim.keymap.del('n', '<C-h>')

return {
  { "<C-h>", "<cmd>SomeFunc<CR>" },
  ...
```