### PR TITLE
fix: restore system parser runtime path when vimdoc parser is missing

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,6 +1,22 @@
 vim.g.base46_cache = vim.fn.stdpath "data" .. "/base46/"
 vim.g.mapleader = " "
 
+local function ensure_system_parsers_on_rtp()
+  if #vim.api.nvim_get_runtime_file("parser/vimdoc.*", false) > 0 then
+    return
+  end
+
+  for _, dir in ipairs { "/usr/lib/nvim", "/usr/lib64/nvim" } do
+    if vim.uv.fs_stat(dir .. "/parser") then
+      vim.opt.rtp:append(dir)
+      return
+    end
+  end
+end
+
+-- Distro packages may ship parsers under /usr/lib*/nvim instead of runtime/.
+ensure_system_parsers_on_rtp()
+
 -- bootstrap lazy and all plugins
 local lazypath = vim.fn.stdpath "data" .. "/lazy/lazy.nvim"
 
@@ -24,6 +40,9 @@ require("lazy").setup({
 
   { import = "plugins" },
 }, lazy_config)
+
+-- lazy can rewrite rtp, so restore system parser path after setup too.
+ensure_system_parsers_on_rtp()
 
 -- load theme
 dofile(vim.g.base46_cache .. "defaults")


### PR DESCRIPTION

  This fixes help-buffer Treesitter failures on distro Neovim packages that place parsers in `/usr/lib/nvim` or `/usr/lib64/nvim`.

  ## Why

  `lazy.setup()` can rewrite `runtimepath`, and on some systems that drops `/usr/lib/nvim`.
  Then builtin Treesitter cannot find `parser/vimdoc.so`, so `:help` fails with:
  `Parser could not be created ... language "vimdoc"`.

  ## What

  - Add a small guard in `init.lua`:
    - If `parser/vimdoc.*` is not found on current `rtp`, append `/usr/lib/nvim` or `/usr/lib64/nvim` if present.
  - Run this guard:
    - before `lazy.setup()`
    - after `lazy.setup()` (because `rtp` can be rewritten there)

  This is a no-op on systems where parser is already discoverable.

  ## Validation

  - `nvim --headless '+h vim.lsp.config' +qall` no longer errors
  - `nvim_get_runtime_file("parser/vimdoc.*", false)` returns system parser path
